### PR TITLE
Updated to version 1.5.4

### DIFF
--- a/zbot/cogs/_command.py
+++ b/zbot/cogs/_command.py
@@ -19,5 +19,5 @@ class Command(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.user = self.bot.user
-        self.guild = bot.get_guild(GUILD_ID)
+        self.guild = self.bot.get_guild(GUILD_ID)
         self.app_id = os.getenv('WG_API_APPLICATION_ID') or 'demo'

--- a/zbot/cogs/info.py
+++ b/zbot/cogs/info.py
@@ -57,7 +57,8 @@ class Info(_command.Command):
             if not matching_commands:
                 raise exceptions.UnknownCommand(command_name)
             else:
-                for command in matching_commands:
+                sorted_matching_commands = sorted(matching_commands, key=lambda c: c.name)
+                for command in sorted_matching_commands:
                     if isinstance(command, commands.Group):
                         await self.display_group_help(context, command, max_nest_level)
                     else:
@@ -73,9 +74,10 @@ class Info(_command.Command):
             if not command.hidden or checker.has_any_mod_role(context, print_error=False):
                 commands_by_cog.setdefault(command.cog, []).append(command)
         for cog in sorted(commands_by_cog, key=lambda c: c.DISPLAY_SEQUENCE):
+            sorted_cog_commands = sorted(commands_by_cog[cog], key=lambda c: c.name)
             embed.add_field(
                 name=cog.DISPLAY_NAME,
-                value="\n".join([f"• `+{command}` : {command.brief}" for command in commands_by_cog[cog]]),
+                value="\n".join([f"• `+{command}` : {command.brief}" for command in sorted_cog_commands]),
                 inline=False
             )
         embed.set_footer(text="Utilisez +help <commande> pour plus d'informations")
@@ -91,10 +93,11 @@ class Info(_command.Command):
             lambda c: not c.hidden or checker.has_any_mod_role(context, print_error=False),
             command_list
         ))
+        sorted_group_commands = sorted(authorized_command_list, key=lambda c: c.name)
         embed = discord.Embed(
             title=group.cog.DISPLAY_NAME,
             description="\n".join([
-                f"• `+{command}` : {command.brief}" for command in authorized_command_list
+                f"• `+{command}` : {command.brief}" for command in sorted_group_commands
             ]),
             color=Info.EMBED_COLOR
         )

--- a/zbot/cogs/messaging.py
+++ b/zbot/cogs/messaging.py
@@ -1,7 +1,11 @@
 import datetime
+import random
 
+import asyncio
 import discord
+from dateutil.relativedelta import relativedelta
 from discord.ext import commands
+from discord.ext import tasks
 
 from zbot import checker
 from zbot import converter
@@ -21,149 +25,32 @@ class Messaging(_command.Command):
     DISPLAY_SEQUENCE = 5
     MOD_ROLE_NAMES = ['Administrateur', 'Modérateur']
     USER_ROLE_NAMES = ['Joueur']
+    EMBED_COLOR = 0x91b6f2  # Pastel blue
 
     PLAYER_ROLE_NAME = 'Joueur'
-    TIMEZONE = converter.GUILD_TIMEZONE
+    TIMEZONE = converter.COMMUNITY_TIMEZONE
     MIN_ACCOUNT_CREATION_DATE = TIMEZONE.localize(datetime.datetime(2011, 4, 11))
     CELEBRATION_CHANNEL_ID = 525037740690112527  # #général
     CELEBRATION_EMOJI = "🕯"
+    AUTOMESSAGE_FREQUENCY = relativedelta(hours=2)  # The time to wait after the last message was posted
+    AUTOMESSAGE_COOLDOWN = relativedelta(hours=12)  # The time to wait before sending two messages in a row
+    AUTOMESSAGE_DELAY = relativedelta(minutes=5)  # The time a channel must have been silent before sending a message
+    LAST_AUTOMESSAGE_ID = None
 
     def __init__(self, bot):
         super().__init__(bot)
-        anniversary_celebration_time = self.TIMEZONE.localize(datetime.datetime.combine(
-            converter.get_tz_aware_local_datetime(), datetime.time(9, 0, 0)
-        ))
-        scheduler.schedule_volatile_job(
-            anniversary_celebration_time,
-            self.celebrate_account_anniversaries,
-            interval=datetime.timedelta(days=1)
-        )
-
-    @commands.command(
-        name='switch',
-        usage='[--number=N] [--ping] [--delete]',
-        brief="Redirige une conversation",
-        help="Suggère au participants d'une conversation dans le canal courant à la poursuivre "
-             "ailleurs. Par défaut, les 3 derniers messages sont copiés dans le canal de "
-             "destination. Pour modifier le nombre de messages à copier, ajoutez l'argument "
-             "`--number=N` où `N` est le nombre de messages à copier (maximum 10). Pour "
-             "respectivement mentionner les auteurs de ces messages ou les supprimer, ajoutez "
-             "l'argument `--ping` ou `--delete` (droits de modération requis).",
-        ignore_extra=True
-    )
-    @commands.check(checker.is_allowed_in_all_channels)
-    @commands.check(checker.has_any_user_role)
-    async def switch(self, context, dest_channel: discord.TextChannel, *, options=""):
-        if context.channel == dest_channel \
-                or not context.author.permissions_in(dest_channel).send_messages:
-            raise exceptions.ForbiddenChannel(dest_channel)
-        number_option = utils.get_option_value(options, 'number')
-        if number_option is not None:  # Value assigned
-            try:
-                messages_number = int(number_option)
-            except ValueError:
-                raise exceptions.MisformattedArgument(number_option, "valeur entière")
-            if messages_number < 1:
-                raise exceptions.UndersizedArgument(messages_number, 1)
-            elif messages_number > 10 and not checker.has_any_mod_role(context, print_error=False):
-                raise exceptions.OversizedArgument(messages_number, 10)
-        elif utils.is_option_enabled(options, 'number', has_value=True):  # No value assigned
-            raise exceptions.MisformattedArgument(number_option, "valeur entière")
-        else:  # Option not used
-            messages_number = 3
-        do_ping = utils.is_option_enabled(options, 'ping')
-        do_delete = utils.is_option_enabled(options, 'delete')
-        if do_ping or do_delete:
-            checker.has_any_mod_role(context, print_error=True)
-
-        messages = await context.channel.history(limit=messages_number+1).flatten()
-        messages.reverse()  # Order by oldest first
-        messages.pop()  # Remove message used for the command
-
-        await context.message.delete()
-        await context.send(
-            f"**Veuillez basculer cette discussion dans le canal {dest_channel.mention} qui serait "
-            f"plus approprié ! 🧹**"
-        )
-        await dest_channel.send(f"**Suite de la discussion de {context.channel.mention} 💨**")
-        await self.move_messages(messages, dest_channel, do_ping, do_delete)
-
-    @staticmethod
-    async def move_messages(messages, dest_channel, do_ping, do_delete):
-
-        async def _flush_buffer():
-            author_mention = current_author.mention if do_ping \
-                else '@' + current_author.display_name
-            await dest_channel.send(f"{author_mention} :\n>>> " + "\n".join(content_buffer))
-            content_buffer.clear()
-
-        content_buffer, current_author = [], None
-        for message in messages:
-            if message.author != current_author and current_author is not None:  # New message batch
-                await _flush_buffer()
-            current_author = message.author
-            content_buffer.append(message.content)
-            if do_delete:
-                await message.delete()
-        await _flush_buffer()
-
-    @commands.group(
-        name='work',
-        brief="Gère les notifications de travaux sur le bot",
-        hidden=False,
-        invoke_without_command=True
-    )
-    @commands.guild_only()
-    async def work(self, context):
-        if context.invoked_subcommand is None:
-            raise exceptions.MissingSubCommand(context.command.name)
-
-    @work.command(
-        name='start',
-        aliases=['begin'],
-        brief="Annonce le début des travaux sur le bot",
-        help="L'annonce est postée dans le canal courant, la commande est supprimée et le status "
-             "est défini sur travaux en cours.",
-        ignore_extra=True
-    )
-    @commands.check(checker.is_allowed_in_current_channel)
-    @commands.check(checker.has_any_mod_role)
-    async def work_start(self, context):
-        zbot.db.update_metadata('work_in_progress', True)
-        await context.message.delete()
-        await context.send(
-            f"**Début des travaux sur le bot {self.user.mention}** :man_factory_worker:"
-        )
-
-    @work.command(
-        name='done',
-        brief="Annonce la fin des travaux sur le bot",
-        help="L'annonce est postée dans le canal courant, la commande est supprimée et le status "
-             "est défini sur travaux terminés.",
-        ignore_extra=True
-    )
-    @commands.check(checker.is_allowed_in_current_channel)
-    @commands.check(checker.has_any_mod_role)
-    async def work_done(self, context):
-        zbot.db.update_metadata('work_in_progress', False)
-        await context.message.delete()
-        await context.send(f"**Fin des travaux sur le bot {self.user.mention}** :mechanical_arm:")
-
-    @work.command(
-        name='status',
-        aliases=['statut'],
-        brief="Affiche l'état des travaux sur le bot",
-        help="Le résultat est posté dans le canal courant.",
-        ignore_extra=True
-    )
-    @commands.check(checker.is_allowed_in_current_channel)
-    @commands.check(checker.has_any_user_role)
-    async def work_status(self, context):
-        work_in_progress = zbot.db.get_metadata('work_in_progress') or False  # Might not be set
-        if work_in_progress:
-            await context.send(f"Les travaux sur le bot sont toujours en cours.")
-        else:
-            await context.send(f"Les travaux sur le bot sont terminés. :ok_hand:")
+        today = converter.get_tz_aware_local_datetime()
+        anniversary_celebration_time = self.TIMEZONE.localize(datetime.datetime.combine(today, datetime.time(9, 0, 0)))
+        last_anniversaries_celebration = zbot.db.get_metadata('last_anniversaries_celebration')
+        if not last_anniversaries_celebration \
+                or last_anniversaries_celebration.date() != anniversary_celebration_time.date():
+            scheduler.schedule_volatile_job(
+                anniversary_celebration_time,
+                self.celebrate_account_anniversaries,
+                interval=datetime.timedelta(days=1)
+            )
+        zbot.db.update_metadata('last_anniversaries_celebration', today)
+        self.send_automessage.start()
 
     async def celebrate_account_anniversaries(self):
         # Get anniversary data
@@ -188,6 +75,7 @@ class Messaging(_command.Command):
                     )
                 except (discord.Forbidden, discord.HTTPException):
                     pass
+
         # Add celebration emojis for today's anniversaries
         for year, members in member_anniversaries.items():
             for member in members:
@@ -237,6 +125,306 @@ class Messaging(_command.Command):
         for member, account_id in members_account_ids.items():
             members_account_data[member].update(creation_date=players_details[account_id][0])
         zbot.db.update_accounts_data(members_account_data)
+
+    @commands.group(
+        name='automessage',
+        brief="Gère les messages automatiques",
+        hidden=True,
+        invoke_without_command=True
+    )
+    @commands.guild_only()
+    async def automessage(self, context):
+        if context.invoked_subcommand is None:
+            raise exceptions.MissingSubCommand(context.command.name)
+
+    @automessage.command(
+        name='add',
+        aliases=['new'],
+        usage='<#channel> <"message">',
+        brief="Ajoute un nouveau message automatique",
+        help="Le bot tire au sort à intervalles réguliers un message automatique parmi ceux existants et le poste dans "
+             "le canal associé.",
+        hidden=True,
+        ignore_extra=False
+    )
+    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_any_mod_role)
+    async def automessage_add(self, context, channel: discord.TextChannel, message: str):
+        if not context.author.permissions_in(channel).send_messages:
+            raise exceptions.ForbiddenChannel(channel)
+
+        automessage_id = self.get_next_automessage_id()
+        zbot.db.insert_automessage(automessage_id, message, channel)
+        await context.send(
+            f"Message automatique d'identifiant `{automessage_id}` créé et lié au canal {channel.mention}."
+        )
+
+    @staticmethod
+    def get_next_automessage_id() -> int:
+        automessage_ids = [
+            automessage_data['automessage_id'] for automessage_data in zbot.db.load_automessages({}, ['automessage_id'])
+        ]
+        return max(automessage_ids) + 1 if automessage_ids else 1
+
+    @automessage.command(
+        name='list',
+        aliases=['l', 'ls'],
+        brief="Affiche la liste des messages automatiques",
+        hidden=True,
+        ignore_extra=False
+    )
+    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_any_mod_role)
+    async def automessage_list(self, context):
+        automessage_descriptions = {}
+        for automessage_data in zbot.db.load_automessages({}, ['automessage_id', 'message', 'channel_id']):
+            automessage_id = automessage_data['automessage_id']
+            message = automessage_data['message']
+            if len(message) > 120:  # Avoid reaching the 2000 chars limit per message
+                message = message[:120] + "..."
+            channel = self.guild.get_channel(automessage_data['channel_id'])
+            automessage_descriptions[automessage_id] = f" • `[{automessage_id}]` dans {channel.mention}: {message}"
+        embed_description = "Aucun" if not automessage_descriptions \
+            else "\n".join([automessage_descriptions[automessage_id]
+                            for automessage_id in sorted(automessage_descriptions.keys())])
+        embed = discord.Embed(
+            title="Message(s) automatique(s)",
+            description=embed_description,
+            color=self.EMBED_COLOR
+        )
+        await context.send(embed=embed)
+
+    @automessage.command(
+        name='print',
+        aliases=['p', 'test'],
+        usage="<automessage_id>",
+        brief="Poste un message automatique",
+        help="Le canal courant est utilisé au lieu du canal associé et toutes les vérifications sont désactivées.",
+        hidden=True,
+        ignore_extra=False
+    )
+    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_any_mod_role)
+    async def automessage_print(self, context, automessage_id: int):
+        automessages_data = zbot.db.load_automessages({'automessage_id': automessage_id}, ['message'])
+        if not automessages_data:
+            raise exceptions.UnknownAutomessage(automessage_id)
+
+        message = automessages_data[0]['message']
+        await context.send(message)
+
+    @automessage.command(
+        name='remove',
+        aliases=['r', 'delete', 'del', 'd'],
+        usage="<automessage_id>",
+        brief="Supprime un message automatique",
+        ignore_extra=False
+    )
+    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_any_mod_role)
+    async def automessage_remove(self, context, automessage_id: int):
+        automessages_data = zbot.db.load_automessages({}, ['_id', 'automessage_id'])
+        automessage_data = [data for data in automessages_data if data['automessage_id'] == automessage_id]
+        if not automessage_data:
+            raise exceptions.UnknownAutomessage(automessage_id)
+        document_id = automessage_data[0]['_id']
+
+        self.remove_automessage(document_id, automessage_id, automessages_data)
+        await context.send(f"Message automatique d'identifiant `{automessage_id}` supprimé.")
+
+    @staticmethod
+    def remove_automessage(document_id, automessage_id, automessages_data):
+        automessages_update_data = {}
+        for automessage_data in automessages_data:
+            if automessage_data['automessage_id'] > automessage_id:
+                automessages_update_data[automessage_data['_id']] = {
+                    'automessage_id': automessage_data['automessage_id'] - 1
+                }
+
+        zbot.db.update_automessages(automessages_update_data)
+        zbot.db.delete_automessage(document_id)
+
+    @tasks.loop(hours=AUTOMESSAGE_FREQUENCY.hours)
+    async def send_automessage(self):
+        automessages_data = zbot.db.load_automessages(
+            {'automessage_id': {'$ne': self.LAST_AUTOMESSAGE_ID}},  # Don't post the same message twice in a row
+            ['automessage_id', 'channel_id', 'message']
+        )
+        if not automessages_data:  # At most a single automessage exists
+            automessages_data = zbot.db.load_automessages(  # Load it anyway
+                {}, ['automessage_id', 'channel_id', 'message']
+            )
+        if automessages_data:
+            automessage_data = random.choice(automessages_data)
+            automessage_id = automessages_data['automessage_id']
+            message = automessage_data['message']
+            channel = self.guild.get_channel(automessage_data['channel_id'])
+            last_channel_message = (await channel.history(limit=1).flatten())[0]
+
+            if last_channel_message.author == self.user:  # Avoid spamming an channel
+                # Check if the cooldown between two bot messages has expired
+                last_channel_message_date = converter.get_tz_aware_guild_datetime(last_channel_message.created_at)
+                now = converter.get_tz_aware_local_datetime()
+                cooldown_expired = last_channel_message_date < now - self.AUTOMESSAGE_COOLDOWN
+                if not cooldown_expired:
+                    return
+            else:  # Avoid interrupting conversations
+                is_channel_quiet, attempt_count = False, 0
+                while not is_channel_quiet:  # Wait for the channel to be quiet to send the message
+                    now = converter.get_tz_aware_local_datetime()
+                    last_channel_message_date = converter.get_tz_aware_guild_datetime(last_channel_message.created_at)
+                    is_channel_quiet = last_channel_message_date < now - self.AUTOMESSAGE_DELAY
+                    if not is_channel_quiet:
+                        attempt_count = +1
+                        if attempt_count == 3:  # After 3 failed attempts, skip
+                            return
+                        else:
+                            await asyncio.sleep(self.AUTOMESSAGE_DELAY.seconds)  # Sleep for the duration of the delay
+
+            # All checks passed, send the automessage
+            self.LAST_AUTOMESSAGE_ID = automessage_id
+            await channel.send(message)
+
+    @commands.command(
+        name='switch',
+        usage='<#dest_channel> [--number=N] [--ping] [--delete]',
+        brief="Redirige une conversation",
+        help="Suggère au participants d'une conversation dans le canal courant à la poursuivre "
+             "ailleurs. Par défaut, les 3 derniers messages sont copiés dans le canal de "
+             "destination. Pour modifier le nombre de messages à copier, ajoutez l'argument "
+             "`--number=N` où `N` est le nombre de messages à copier (maximum 10). Pour "
+             "respectivement mentionner les auteurs de ces messages ou les supprimer, ajoutez "
+             "l'argument `--ping` ou `--delete` (droits de modération requis).",
+        ignore_extra=True
+    )
+    @commands.check(checker.is_allowed_in_all_channels)
+    @commands.check(checker.has_any_user_role)
+    async def switch(self, context, dest_channel: discord.TextChannel, *, options=""):
+        if context.channel == dest_channel \
+                or not context.author.permissions_in(dest_channel).send_messages:
+            raise exceptions.ForbiddenChannel(dest_channel)
+        number_option = utils.get_option_value(options, 'number')
+        if number_option is not None:  # Value assigned
+            try:
+                messages_number = int(number_option)
+            except ValueError:
+                raise exceptions.MisformattedArgument(number_option, "valeur entière")
+            if messages_number < 0:
+                raise exceptions.UndersizedArgument(messages_number, 0)
+            elif messages_number > 10 and not checker.has_any_mod_role(context, print_error=False):
+                raise exceptions.OversizedArgument(messages_number, 10)
+        elif utils.is_option_enabled(options, 'number', has_value=True):  # No value assigned
+            raise exceptions.MisformattedArgument(number_option, "valeur entière")
+        else:  # Option not used
+            messages_number = 3
+        do_ping = utils.is_option_enabled(options, 'ping')
+        do_delete = utils.is_option_enabled(options, 'delete')
+        if do_ping or do_delete:
+            checker.has_any_mod_role(context, print_error=True)
+
+        messages = await context.channel.history(limit=messages_number+1).flatten()
+        messages.reverse()  # Order by oldest first
+        messages.pop()  # Remove message used for the command
+
+        await context.message.delete()
+        if not do_delete:
+            await context.send(
+                f"**Veuillez basculer cette discussion dans le canal {dest_channel.mention} qui "
+                f"serait plus approprié !** 🧹"
+            )
+        else:
+            await context.send(
+                f"**La discussion a été déplacée dans le canal {dest_channel.mention} !** "
+                f"({len(messages)} messages supprimés) 🧹"
+            )
+        if messages_number != 0:
+            await dest_channel.send(f"**Suite de la discussion de {context.channel.mention}** 💨")
+        await self.move_messages(messages, dest_channel, do_ping, do_delete)
+
+    @staticmethod
+    async def move_messages(messages, dest_channel, do_ping, do_delete):
+
+        async def _flush_buffer():
+            if content_buffer:
+                author_mention = current_author.mention if do_ping \
+                    else '@' + current_author.display_name
+                await dest_channel.send(f"{author_mention} :\n>>> " + "\n".join(content_buffer))
+                content_buffer.clear()
+
+        content_buffer, current_author = [], None
+        for message in messages:
+            if message.author != current_author and current_author is not None:  # New message batch
+                await _flush_buffer()
+            current_author = message.author
+            content_buffer.append(message.content)
+            if do_delete:
+                await message.delete()
+        await _flush_buffer()
+
+    @commands.group(
+        name='work',
+        brief="Gère les notifications de travaux sur le bot",
+        invoke_without_command=True
+    )
+    @commands.guild_only()
+    async def work(self, context):
+        if context.invoked_subcommand is None:
+            raise exceptions.MissingSubCommand(context.command.name)
+
+    @work.command(
+        name='start',
+        aliases=['begin'],
+        brief="Annonce le début des travaux sur le bot",
+        help="L'annonce est postée dans le canal courant, la commande est supprimée et le status "
+             "est défini sur travaux en cours.",
+        hidden=True,
+        ignore_extra=True
+    )
+    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_any_mod_role)
+    async def work_start(self, context):
+        zbot.db.update_metadata('work_in_progress', True)
+        await context.message.delete()
+        await context.send(
+            f"**Début des travaux sur le bot {self.user.mention}** :man_factory_worker:"
+        )
+
+    @work.command(
+        name='done',
+        brief="Annonce la fin des travaux sur le bot",
+        help="L'annonce est postée dans le canal courant, la commande est supprimée et le status "
+             "est défini sur travaux terminés.",
+        hidden=True,
+        ignore_extra=True
+    )
+    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_any_mod_role)
+    async def work_done(self, context):
+        zbot.db.update_metadata('work_in_progress', False)
+        await context.message.delete()
+        await context.send(
+            f"**Fin des travaux sur le bot {self.user.mention}** :mechanical_arm:"
+        )
+
+    @work.command(
+        name='status',
+        aliases=['statut'],
+        brief="Affiche l'état des travaux sur le bot",
+        help="Le résultat est posté dans le canal courant.",
+        ignore_extra=True
+    )
+    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_any_user_role)
+    async def work_status(self, context):
+        work_in_progress = zbot.db.get_metadata('work_in_progress') or False  # Might not be set
+        if work_in_progress:
+            await context.send(
+                f"**Les travaux sur le bot {self.user.mention} sont toujours en cours** :tools:"
+            )
+        else:
+            await context.send(
+                f"**Les travaux sur le bot {self.user.mention} sont terminés** :ok_hand:"
+            )
 
 
 def setup(bot):

--- a/zbot/converter.py
+++ b/zbot/converter.py
@@ -11,7 +11,8 @@ from dateutil.tz import tzlocal
 from zbot import zbot
 from . import exceptions
 
-GUILD_TIMEZONE = pytz.timezone('Europe/Brussels')
+COMMUNITY_TIMEZONE = pytz.timezone('Europe/Brussels')
+GUILD_TIMEZONE = pytz.timezone('UTC')
 
 
 # Time and timezone manipulations
@@ -20,7 +21,7 @@ def to_datetime(instant: str, print_error=True) -> datetime.datetime:
     local_time = None
     try:
         time = dateutil.parser.parse(instant)
-        local_time = GUILD_TIMEZONE.localize(time)
+        local_time = COMMUNITY_TIMEZONE.localize(time)
     except (ValueError, OverflowError):
         if print_error:
             raise exceptions.MisformattedArgument(instant, "YYYY-MM-MM HH:MM:SS")
@@ -41,6 +42,10 @@ def humanize_datetime(time: datetime.datetime) -> str:
 
 def get_tz_aware_local_datetime() -> datetime.datetime:
     return datetime.datetime.now(tzlocal())
+
+
+def get_tz_aware_guild_datetime(time: datetime.datetime) -> datetime.datetime:
+    return GUILD_TIMEZONE.localize(time)
 
 
 # Emojis manipulations

--- a/zbot/database.py
+++ b/zbot/database.py
@@ -5,6 +5,7 @@ from typing import Dict
 from typing import List
 from typing import Tuple
 
+import discord
 import pymongo
 from dateutil.relativedelta import relativedelta
 from pymongo.errors import ConnectionFailure
@@ -16,12 +17,14 @@ from . import logger
 class MongoDBConnector:
 
     ACCOUNT_DATA_COLLECTION = 'account_data'
+    AUTOMESSAGES_COLLECTION = 'automessage'
     METADATA_COLLECTION = 'metadata'  # Collection of data about bot jobs and data
     PENDING_LOTTERIES_COLLECTION = 'pending_lottery'
     PENDING_POLLS_COLLECTION = 'pending_poll'
     RECRUITMENT_ANNOUNCES_COLLECTION = 'recruitment_announce'
     COLLECTIONS_CONFIG = {
         ACCOUNT_DATA_COLLECTION: {},
+        AUTOMESSAGES_COLLECTION: {},
         METADATA_COLLECTION: {},
         PENDING_LOTTERIES_COLLECTION: {'is_jobstore': True},
         PENDING_POLLS_COLLECTION: {'is_jobstore': True},
@@ -81,6 +84,15 @@ class MongoDBConnector:
 
     # Admin
 
+    def insert_recruitment_announce(self, member: discord.Member, time: datetime.datetime):
+        res = self.database[self.RECRUITMENT_ANNOUNCES_COLLECTION].insert_one({
+            'author': member.id,
+            'time': time,
+            'dummy': True,
+        })
+        logger.debug(f"Inserted dummy recruitment announce of id {res.inserted_id}.")
+        return res.inserted_id
+
     def update_recruitment_announces(self, announces):
         upsert_count = 0
         for announce in announces:
@@ -90,12 +102,10 @@ class MongoDBConnector:
                 upsert=True
             )
             upsert_count += bool(res.upserted_id)
-        logger.debug(f"Inserted or updated {upsert_count} recruitment announce(s).")
+        logger.debug(f"Updated {upsert_count} recruitment announce(s).")
 
-    def delete_recruitment_announces_by_author(self, member_id):
-        res = self.database[self.RECRUITMENT_ANNOUNCES_COLLECTION].delete_many(
-            {'author': member_id}
-        )
+    def delete_recruitment_announces(self, query):
+        res = self.database[self.RECRUITMENT_ANNOUNCES_COLLECTION].delete_many(query)
         logger.debug(f"Deleted {res.deleted_count} recruitment announce(s).")
 
     def load_recruitment_announces_data(self, query: Dict[str, Any], order: List[Tuple[str, int]]):
@@ -109,9 +119,14 @@ class MongoDBConnector:
     def delete_job_data(self, collection_name, job_id):
         self.database[collection_name].delete_one({'_id': job_id})
 
-    def load_pending_jobs_data(self, collection_name, pending_jobs_data, data_keys):
-        for pending_job in self.database[collection_name].find({}, dict.fromkeys(data_keys, 1)):
-            pending_jobs_data[pending_job['message_id']] = dict(pending_job)
+    def load_pending_jobs_data(self, collection_name, data_keys):
+        pending_jobs_data = {}
+        for pending_job_data in self.database[collection_name].find({}, dict.fromkeys(data_keys, 1)):
+            pending_jobs_data[pending_job_data['message_id']] = pending_job_data
+        logger.debug(
+            f"Loaded {len(pending_jobs_data)} pending data from collection {collection_name}: {pending_jobs_data}"
+        )
+        return pending_jobs_data
 
     # Messaging
 
@@ -124,7 +139,7 @@ class MongoDBConnector:
                 upsert=True
             )
             upsert_count += bool(res.upserted_id)
-        logger.debug(f"Inserted or updated {upsert_count} account data.")
+        logger.debug(f"Updated {upsert_count} account data.")
 
     def get_unrecorded_members(self, members):
         accounts_data = self.database[self.ACCOUNT_DATA_COLLECTION].find({}, {'_id': 1})
@@ -135,7 +150,7 @@ class MongoDBConnector:
             self, reference_date: datetime.datetime, min_account_creation_date: datetime.datetime
     ):
         # Initialize anniversary dates at midnight one year ago
-        anniversary_day = converter.GUILD_TIMEZONE.localize(datetime.datetime.combine(
+        anniversary_day = converter.COMMUNITY_TIMEZONE.localize(datetime.datetime.combine(
             reference_date.date() - relativedelta(years=1), datetime.time(0, 0)
         ))
         day_after_anniversary = anniversary_day + relativedelta(days=1)
@@ -161,3 +176,28 @@ class MongoDBConnector:
             f"account anniversaries: {', '.join(display_names)}"
         )
         return account_anniversaries
+
+    def insert_automessage(self, automessage_id: int, message: str, channel: discord.TextChannel):
+        res = self.database[self.AUTOMESSAGES_COLLECTION].insert_one({
+            'automessage_id': automessage_id,
+            'message': message,
+            'channel_id': channel.id
+        })
+        logger.debug(f"Inserted auto-message of id {automessage_id} in document {res.inserted_id}.")
+        return res.inserted_id
+
+    def update_automessages(self, automessages_data):
+        for key, automessage_data in automessages_data.items():
+            self.database[self.AUTOMESSAGES_COLLECTION].update_one(
+                {'_id': key},
+                {'$set': automessage_data}
+            )
+
+    def delete_automessage(self, document_id):
+        self.database[self.AUTOMESSAGES_COLLECTION].delete_one({'_id': document_id})
+
+    def load_automessages(self, query, data_keys):
+        automessages_data = []
+        for automessage_data in self.database[self.AUTOMESSAGES_COLLECTION].find(query, dict.fromkeys(data_keys, 1)):
+            automessages_data.append({k: automessage_data[k] for k in automessage_data if k in data_keys})
+        return automessages_data

--- a/zbot/error_handler.py
+++ b/zbot/error_handler.py
@@ -75,8 +75,9 @@ async def handle(context, error):
     elif isinstance(error, exceptions.UnknownCommand):
         await context.send(f"Commande inconnue : `{error.unknown_command_name}`")
     elif any(isinstance(error, error_type) for error_type in (
+        exceptions.UnknownAutomessage,
         exceptions.UnknownLottery,
-        exceptions.UnknownPoll
+        exceptions.UnknownPoll,
     )):
         await context.send(f"Identifiant inconnu : `{error.unknown_id}`")
     elif isinstance(error, exceptions.UnknownPlayer):

--- a/zbot/exceptions.py
+++ b/zbot/exceptions.py
@@ -67,6 +67,11 @@ class UndersizedArgument(commands.CommandError):
         self.min_size = min_size
 
 
+class UnknownAutomessage(commands.CommandError):
+    def __init__(self, unknown_automessage_id):
+        self.unknown_id = unknown_automessage_id
+
+
 class UnknownClan(commands.CommandError):
     def __init__(self, unknown_clan_name):
         self.unknown_clan_name = unknown_clan_name

--- a/zbot/scheduler.py
+++ b/zbot/scheduler.py
@@ -21,8 +21,10 @@ def setup(db: database.MongoDBConnector):
         jobstore = MongoDBJobStore(database=db.database_name, collection=collection_name, client=db.client)
         scheduler.add_jobstore(jobstore, alias=collection_name)
     scheduler.start()
-    logger.debug(f"Loaded {len(scheduler.get_jobs())} job(s): "
-                 f"{', '.join([job.id for job in scheduler.get_jobs()])}")
+    jobs = scheduler.get_jobs()
+    logger.debug(
+        f"Loaded {len(jobs)} job(s)" + (f": {', '.join([job.id for job in jobs])}" if jobs else ".")
+    )
 
 
 def get_job_run_date(job_id):

--- a/zbot/zbot.py
+++ b/zbot/zbot.py
@@ -13,7 +13,7 @@ from . import error_handler
 from . import logger
 from . import scheduler
 
-__version__ = '1.5.3'
+__version__ = '1.5.4'
 
 dotenv.load_dotenv()
 


### PR DESCRIPTION
- Added the command 'automessage' and its subcommands 'automessage add', 'automessage list', 'automessage print' and 'automessage delete' to manage automessages. Closes #15
- Added an argument `time` to the 'clear recruitment' command to only effectively clear the logs as of that time.
- Made it possible to set `--number` argument of command `switch` to 0.
- Made the command 'help' output results in alphabetical order.
- Stopped creating the anniversaries celebration job if it already ran the same day.