### PR TITLE
Updated to version 1.5.5

### DIFF
--- a/zbot/cogs/admin.py
+++ b/zbot/cogs/admin.py
@@ -51,7 +51,8 @@ class Admin(_command.Command):
         hidden=True,
         invoke_without_command=True
     )
-    @commands.guild_only()
+    @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def check(self, context):
         if context.invoked_subcommand is None:
             raise exceptions.MissingSubCommand(context.command.name)
@@ -64,8 +65,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def check_all(self, context):
         await context.message.add_reaction(self.WORK_IN_PROGRESS_EMOJI)
 
@@ -87,8 +88,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def check_everyone(self, context, add_reaction=True):
         add_reaction and await context.message.add_reaction(self.WORK_IN_PROGRESS_EMOJI)
 
@@ -140,8 +141,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def check_players(self, context, add_reaction=True):
         add_reaction and await context.message.add_reaction(self.WORK_IN_PROGRESS_EMOJI)
 
@@ -218,8 +219,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def check_contacts(self, context, add_reaction=True):
         add_reaction and await context.message.add_reaction(self.WORK_IN_PROGRESS_EMOJI)
 
@@ -329,8 +330,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def check_recruitments(
             self, context,
             after: converter.to_datetime = converter.to_datetime('1970-01-01'),
@@ -502,7 +503,8 @@ class Admin(_command.Command):
         hidden=True,
         invoke_without_command=True
     )
-    @commands.guild_only()
+    @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def clear(self, context):
         if context.invoked_subcommand is None:
             raise exceptions.MissingSubCommand(context.command.name)
@@ -518,8 +520,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=True
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def clear_recruitment(self, context, member: discord.Member, time: converter.to_datetime = None):
         zbot.db.delete_recruitment_announces({'author': member.id})
         if time:
@@ -537,7 +539,8 @@ class Admin(_command.Command):
         hidden=True,
         invoke_without_command=True
     )
-    @commands.guild_only()
+    @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def report(self, context):
         if context.invoked_subcommand is None:
             raise exceptions.MissingSubCommand(context.command.name)
@@ -562,8 +565,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def report_recruitment(self, context, announce_id: int):
         recruitment_channel = self.guild.get_channel(self.RECRUITMENT_CHANNEL_ID)
         recruitment_announce = await utils.try_get_message(
@@ -632,8 +635,8 @@ class Admin(_command.Command):
         hidden=True,
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_all_channels)
     async def logout(self, context):
         logger.info("Logging out...")
         await context.send(f"Déconnexion.")

--- a/zbot/cogs/info.py
+++ b/zbot/cogs/info.py
@@ -35,7 +35,8 @@ class Info(_command.Command):
              "l'argument `--nest=level` où `level` est le nombre de niveaux à parcourir.",
         ignore_extra=False,
     )
-    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_no_role_requirement)
+    @commands.check(checker.is_allowed_in_private_or_current_guild_channel)
     async def help(self, context, *, args: str = ""):
         max_nest_level = utils.get_option_value(args, 'nest')
         if max_nest_level:
@@ -149,7 +150,8 @@ class Info(_command.Command):
              "soit en développement et que la version de celui-ci ne corresponde donc pas à celle du code source.",
         ignore_extra=False,
     )
-    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_no_role_requirement)
+    @commands.check(checker.is_allowed_in_private_or_current_guild_channel)
     async def version(self, context):
         bot_display_name = await self.get_bot_display_name(self.user, self.guild)
         embed = discord.Embed(
@@ -167,7 +169,8 @@ class Info(_command.Command):
              "Les droits d'utilisation du code source sont repris dans le fichier LICENSE.",
         ignore_extra=False,
     )
-    @commands.check(checker.is_allowed_in_current_channel)
+    @commands.check(checker.has_no_role_requirement)
+    @commands.check(checker.is_allowed_in_private_or_current_guild_channel)
     async def source(self, context):
         bot_display_name = await self.get_bot_display_name(self.user, self.guild)
         embed = discord.Embed(

--- a/zbot/cogs/lottery.py
+++ b/zbot/cogs/lottery.py
@@ -49,7 +49,8 @@ class Lottery(_command.Command):
         brief="Gère les tirages au sort",
         invoke_without_command=True
     )
-    @commands.guild_only()
+    @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def lottery(self, context):
         if context.invoked_subcommand is None:
             raise exceptions.MissingSubCommand(context.command.name)
@@ -68,8 +69,8 @@ class Lottery(_command.Command):
              "ajouter l'argument `--no-announce`.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_mod_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def setup(
             self, context: commands.Context,
             announce: str,
@@ -117,7 +118,9 @@ class Lottery(_command.Command):
         self.pending_lotteries[message.id] = lottery_data
 
         # Confirm command
-        await context.send(f"Tirage au sort d'identifiant `{lottery_data['lottery_id']}` programmé : <{message.jump_url}>.")
+        await context.send(
+            f"Tirage au sort d'identifiant `{lottery_data['lottery_id']}` programmé : <{message.jump_url}>."
+        )
 
     @staticmethod
     def build_announce_embed(emoji, nb_winners, organizer, time, guild_roles):
@@ -181,8 +184,8 @@ class Lottery(_command.Command):
         brief="Affiche la liste des tirages au sort en cours",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def list(self, context: commands.Context):
         lottery_descriptions, guild_id = {}, self.guild.id
         for message_id, lottery_data in self.pending_lotteries.items():
@@ -211,8 +214,8 @@ class Lottery(_command.Command):
              "sort se base dessus pour le choix des gagnants.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def pick(self, context: commands.Context, lottery_id: int, seed: int = None):
         message, _, _, _, _, organizer = await self.get_message_env(
             lottery_id, raise_if_not_found=True
@@ -255,8 +258,8 @@ class Lottery(_command.Command):
         help="Le numéro de loterie est affiché entre crochets par la commande `+lottery list`.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def cancel(self, context: commands.Context, lottery_id: int):
         message, _, emoji, _, _, organizer = await self.get_message_env(
             lottery_id, raise_if_not_found=False)
@@ -281,8 +284,8 @@ class Lottery(_command.Command):
         brief="Modifie un tirage au sort",
         invoke_without_command=True
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def edit(self, context):
         if context.invoked_subcommand is None:
             raise exceptions.MissingSubCommand(f'lottery {context.command.name}')
@@ -298,8 +301,8 @@ class Lottery(_command.Command):
              "Dans tous les cas, les membres du serveur ne seront pas notifiés.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def announce(
             self, context: commands.Context,
             lottery_id: int,
@@ -334,8 +337,8 @@ class Lottery(_command.Command):
              "Les réactions à l'ancien émoji ne sont pas prises en compte.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def emoji(
             self, context: commands.Context,
             lottery_id: int,
@@ -374,8 +377,8 @@ class Lottery(_command.Command):
         help="Le précédent organisateur du tirage au sort est remplacé par l'organisateur fourni.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def organizer(
             self, context: commands.Context,
             lottery_id: int,
@@ -408,8 +411,8 @@ class Lottery(_command.Command):
              "format `\"YYYY-MM-DD HH:MM:SS\"`). ",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def time(
             self, context: commands.Context,
             lottery_id: int,
@@ -446,8 +449,8 @@ class Lottery(_command.Command):
              "gagnants fourni.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def winners(
             self, context: commands.Context,
             lottery_id: int,
@@ -528,8 +531,8 @@ class Lottery(_command.Command):
              "des gagnants.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def simulate(
             self, context: commands.Context,
             src_channel: discord.TextChannel,

--- a/zbot/cogs/poll.py
+++ b/zbot/cogs/poll.py
@@ -48,7 +48,8 @@ class Poll(_command.Command):
         brief="Gère les sondages",
         invoke_without_command=True
     )
-    @commands.guild_only()
+    @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def poll(self, context):
         if context.invoked_subcommand is None:
             raise exceptions.MissingSubCommand(context.command.name)
@@ -71,8 +72,8 @@ class Poll(_command.Command):
              "`--pin`.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def start(
             self, context: commands.Context,
             announce: str,
@@ -229,8 +230,8 @@ class Poll(_command.Command):
         brief="Affiche la liste des sondages en cours",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def list(self, context: commands.Context):
         poll_descriptions, guild_id = {}, self.guild.id
         for message_id, poll_data in self.pending_polls.items():
@@ -258,8 +259,8 @@ class Poll(_command.Command):
         help="Force un sondage à se terminer à l'avance.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def assess(self, context: commands.Context, poll_id: int):
         message, _, _, _, _, _, organizer = await self.get_message_env(
             poll_id, raise_if_not_found=True
@@ -304,8 +305,8 @@ class Poll(_command.Command):
         help="Le numéro de sondage est affiché entre crochets par la commande `+poll list`.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def cancel(self, context: commands.Context, poll_id: int):
         message, _, emoji_list, _, _, _, organizer = await self.get_message_env(
             poll_id, raise_if_not_found=False)
@@ -333,8 +334,8 @@ class Poll(_command.Command):
         brief="Modifie un sondage",
         invoke_without_command=True
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def edit(self, context):
         if context.invoked_subcommand is None:
             raise exceptions.MissingSubCommand(f'poll {context.command.name}')
@@ -352,8 +353,8 @@ class Poll(_command.Command):
              "précédente annonce était épinglée, elle sera désépinglée).",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def announce(
             self, context: commands.Context,
             poll_id: int,
@@ -395,8 +396,8 @@ class Poll(_command.Command):
              "message fourni.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def description(self, context: commands.Context, poll_id: int, description: str):
         message, channel, _, is_exclusive, required_role_name, time, organizer = \
             await self.get_message_env(poll_id, raise_if_not_found=True)
@@ -426,8 +427,8 @@ class Poll(_command.Command):
              "émojis non repris ne sont pas prises en compte.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def emojis(
             self, context: commands.Context,
             poll_id: int,
@@ -492,8 +493,8 @@ class Poll(_command.Command):
         help="Le précédent organisateur du sondage est remplacé par l'organisateur fourni.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def organizer(
             self, context: commands.Context,
             poll_id: int,
@@ -531,8 +532,8 @@ class Poll(_command.Command):
              "format `\"YYYY-MM-DD HH:MM:SS\"`). ",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def time(
             self, context: commands.Context,
             poll_id: int,
@@ -622,8 +623,8 @@ class Poll(_command.Command):
              "respectivement ajouter les arguments `--exclusive` et `--role=\"Nom de rôle\"`.",
         ignore_extra=False
     )
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def simulate(
             self, context: commands.Context,
             src_channel: discord.TextChannel,

--- a/zbot/cogs/stats.py
+++ b/zbot/cogs/stats.py
@@ -68,9 +68,8 @@ class Stats(_command.Command):
              "Si aucun nom n'est fourni, le surnom du membre du serveur appellant la commande sera utilisé.",
         ignore_extra=False,
     )
-    @commands.guild_only()
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def stats(self, context, player: typing.Union[discord.Member, str] = None):
         if not self.exp_values:
             self.exp_values = wot_utils.load_exp_values(
@@ -134,9 +133,8 @@ class Stats(_command.Command):
              "Si aucun nom n'est fourni, le surnom du membre du serveur appellant la commande sera utilisé.",
         ignore_extra=False,
     )
-    @commands.guild_only()
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def profile(self, context, player: typing.Union[discord.Member, str] = None):
         player, player_name = utils.parse_player(context.guild, player, context.author)
         player_name, player_id = wot_utils.get_exact_player_info(player_name, self.app_id)
@@ -207,9 +205,8 @@ class Stats(_command.Command):
              "sera utilisé pour chercher le clan correspondant.",
         ignore_extra=False,
     )
-    @commands.guild_only()
-    @commands.check(checker.is_allowed_in_current_channel)
     @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
     async def clan(self, context, clan_search_field: typing.Union[discord.Member, str] = None):
         clan_id = None
         if not clan_search_field or isinstance(clan_search_field, discord.Member):

--- a/zbot/converter.py
+++ b/zbot/converter.py
@@ -40,11 +40,15 @@ def humanize_datetime(time: datetime.datetime) -> str:
     return time.strftime('%d/%m/%Y à %Hh%M')
 
 
-def get_tz_aware_local_datetime() -> datetime.datetime:
+def get_tz_aware_datetime_now() -> datetime.datetime:
     return datetime.datetime.now(tzlocal())
 
 
-def get_tz_aware_guild_datetime(time: datetime.datetime) -> datetime.datetime:
+def to_community_tz(time: datetime.datetime) -> datetime.datetime:
+    return COMMUNITY_TIMEZONE.localize(time)
+
+
+def to_guild_tz(time: datetime.datetime) -> datetime.datetime:
     return GUILD_TIMEZONE.localize(time)
 
 

--- a/zbot/zbot.py
+++ b/zbot/zbot.py
@@ -13,7 +13,7 @@ from . import error_handler
 from . import logger
 from . import scheduler
 
-__version__ = '1.5.4'
+__version__ = '1.5.5'
 
 dotenv.load_dotenv()
 


### PR DESCRIPTION
- Added the command 'automessage edit' and its subcommands 'automessage edit channel' and 'automessage edit message' to edit existing automessages. Closes #16
- Added the argument '--raw' to the command 'automessage print' to print the automessage content in raw text format.
- Made the automessages loop abort if running above defined frequency.
- Reworked permission and channel checks.