### PR TITLE
Updated to version 1.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ python-dotenv
 pytz
 matplotlib
 requests
+tzlocal

--- a/zbot/checker.py
+++ b/zbot/checker.py
@@ -70,7 +70,7 @@ async def is_allowed_in_private_or_current_guild_channel(context):
 async def is_allowed_in_current_guild_channel(context):
     if context.channel.type.name == 'private':
         raise commands.NoPrivateMessage()
-    if context.channel.name not in context.cog.ALLOWED_CHANNELS \
+    if context.channel.name not in context.cog.COMMAND_CHANNELS \
             and not has_any_mod_role(context, print_error=False):
         try:
             await context.message.add_reaction("❌")

--- a/zbot/cogs/_command.py
+++ b/zbot/cogs/_command.py
@@ -13,7 +13,7 @@ class Command(commands.Cog):
     DISPLAY_SEQUENCE = 99
     MOD_ROLE_NAMES = ['Administrateur']
     USER_ROLE_NAMES = []
-    ALLOWED_CHANNELS = ['spam', 'zbot', 'modération', 'logs']
+    COMMAND_CHANNELS = ['spam', 'zbot', 'modération', 'logs']
     EMBED_COLOR = 0xFAA61A  # Mention message color (gold)
 
     def __init__(self, bot):

--- a/zbot/cogs/admin.py
+++ b/zbot/cogs/admin.py
@@ -472,9 +472,11 @@ class Admin(_command.Command):
         before_timespan_announces = []
         for announce in announces:
             if announce_data := author_last_announce_data.get(announce.author.id):
-                previous_announce_time = announce_data['time']
-                if previous_announce_time <= announce.created_at < previous_announce_time + min_timespan:
-                    before_timespan_announces.append((announce, previous_announce_time))
+                previous_announce_time_localized = converter.to_utc(announce_data['time'])
+                if previous_announce_time_localized \
+                        <= converter.to_utc(announce.created_at) \
+                        < previous_announce_time_localized + min_timespan:
+                    before_timespan_announces.append((announce, previous_announce_time_localized))
         if before_timespan_announces:
             for block in utils.make_message_blocks([
                 f"L'annonce de {announce.author.mention} a été postée avant le délai minimum de "

--- a/zbot/cogs/lottery.py
+++ b/zbot/cogs/lottery.py
@@ -219,7 +219,7 @@ class Lottery(_command.Command):
     @staticmethod
     async def run_lottery(message_id, seed=None, manual_run=False):
         lottery_id = Lottery.pending_lotteries[message_id]['lottery_id']
-        message, channel, emoji, nb_winners, time, organizer = await Lottery.get_message_env(
+        message, channel, emoji, nb_winners, _, organizer = await Lottery.get_message_env(
             lottery_id
         )
         try:

--- a/zbot/cogs/server.py
+++ b/zbot/cogs/server.py
@@ -28,39 +28,52 @@ class Server(_command.Command):
     USER_ROLE_NAMES = ['Joueur']
     EMBED_COLOR = 0x91b6f2  # Pastel blue
 
-    MEMBER_COUNT_FREQUENCY = datetime.timedelta(hours=1)  # How often members are counted
+    SERVER_STATS_RECORD_FREQUENCY = datetime.timedelta(hours=1)  # How often server stats are recorded
     HOURS_GRANULARITY_LIMIT = 3  # In days, the maximum time-frame (excl.) to display records on a datetime axis
     DAYS_GRANULARITY_LIMIT = 365  # In days, the maximum time-frame (excl.) to display records on a day-to-day date axis
     MONTHS_GRANULARITY_LIMIT = 365*2  # In days, the maximum time-frame (excl.) to display records on a month axis
-
+    DISCUSSION_CHANNELS = [
+        'général', 'gameplay', 'mentorat', 'actualités', 'promotion', 'recrutement', 'suggestions', 'memes']
     PRIMARY_ROLES = [
-        'Administrateur',
-        'Modérateur',
-        'Wargaming',
-        'Contributeur',
-        'Mentor',
-        'Contact de clan',
-        'Joueur',
-        'Visiteur',
+        'Administrateur', 'Modérateur', 'Wargaming', 'Contributeur', 'Mentor', 'Contact de clan', 'Joueur', 'Visiteur',
     ]
 
     def __init__(self, bot):
         super().__init__(bot)
-        self.record_member_count.start()
+        self.record_server_stats.start()
 
-    @tasks.loop(seconds=MEMBER_COUNT_FREQUENCY.seconds)
-    async def record_member_count(self):
-        now = converter.get_tz_aware_datetime_now()
-        last_member_count_date = zbot.db.get_metadata('last_member_count_date')
-        if last_member_count_date:
-            last_member_count_date_localized = converter.to_guild_tz(last_member_count_date)  # MongoDB uses UTC
-            if last_member_count_date_localized >= now - self.MEMBER_COUNT_FREQUENCY:
-                logger.debug(f"Prevented recording member count because running above define frequency.")
+    @tasks.loop(seconds=SERVER_STATS_RECORD_FREQUENCY.seconds)
+    async def record_server_stats(self):
+        now = utils.com_tz_now()
+        last_server_stats_record_date = zbot.db.get_metadata('last_server_stats_record')
+        if last_server_stats_record_date:
+            last_server_stats_record_date_localized = converter.to_utc(last_server_stats_record_date)
+            if not utils.is_time_almost_elapsed(
+                last_server_stats_record_date_localized,
+                now,
+                self.SERVER_STATS_RECORD_FREQUENCY,
+                tolerance=datetime.timedelta(minutes=5)
+            ):
+                logger.debug(f"Prevented recording server stats because running above define frequency.")
                 return
 
-        member_count = len(self.guild.members)
-        zbot.db.insert_timed_member_count(member_count, now)
-        zbot.db.update_metadata('last_member_count_date', now)
+        await self.record_member_count(now)
+        await self.record_message_count(now)
+        zbot.db.update_metadata('last_server_stats_record', now)
+
+    async def record_member_count(self, time):
+        zbot.db.insert_timed_member_count(time, self.guild.member_count)
+
+    async def record_message_count(self, time):
+        message_counts = []
+        for channel_name in self.DISCUSSION_CHANNELS:
+            channel = utils.try_get(self.guild.channels, name=channel_name)
+            channel_message_count = len(await channel.history(
+                after=converter.to_utc(time - datetime.timedelta(hours=1)).replace(tzinfo=None),
+                limit=999
+            ).flatten())
+            message_counts.append({'count': channel_message_count, 'channel_id': channel.id})
+        zbot.db.insert_timed_message_counts(time, message_counts)
 
     @commands.command(
         name='members',
@@ -111,16 +124,116 @@ class Server(_command.Command):
 
     @graph.command(
         name='members',
-        aliases=['membres', 'joueurs', 'total'],
-        usage="[--time=days]",
+        aliases=['membres'],
+        usage="[--time=days] [--hour|--day|--month|--year]",
         brief="Affiche le total des membres du serveur au cours du temps",
         help="Par défaut, une période de 30 jours est utilisée. Pour changer cela il faut fournir l'argument "
-             "`--time=days` où `days` est le nombre de jours à considérer.",
+             "`--time=days` où `days` est le nombre de jours à considérer. L'axe du temps est automatiquement ajusté "
+             "au nombre de jours : Jusqu'à une période de 3 jours, 12 mois et 2 ans (exclus), l'axe affiche "
+             "respectivement des heures, des jours et des mois. Pour forcer un type d'affichage, il faut fournir l'un "
+             "des arguments suivants : `--hour`, `--day`, `--month`, `--year`. Il est également possible de scinder "
+             "l'affichage par rôle en fournissant l'argument `--split`.",
         ignore_extra=True,
     )
     @commands.check(checker.has_any_user_role)
     @commands.check(checker.is_allowed_in_current_guild_channel)
     async def graph_members(self, context, *, options=""):
+        days_number, granularity = await self.parse_time_arguments(options)
+
+        # Load, compute and reshape data
+        today = utils.com_tz_now()
+        time_limit = today - datetime.timedelta(days=days_number)
+        member_counts_data = zbot.db.load_member_counts({'time': {'$gt': time_limit}}, ['time', 'count'])
+        times, counts = [], []
+        if granularity == 'hour':  # Plot the time and exact value to place the dot accurately
+            for data in member_counts_data:
+                localized_time = converter.to_community_tz(converter.to_utc(data['time']))
+                times.append(localized_time)
+                counts.append(data['count'])
+        elif granularity in ('day', 'month', 'year'):  # Only plot the date and the average value to align with the tick
+            counts_by_date = {}
+            for data in member_counts_data:
+                localized_time = converter.to_community_tz(converter.to_utc(data['time']))
+                counts_by_date.setdefault(localized_time.date(), []).append(data['count'])
+            times.extend(counts_by_date.keys())
+            counts.extend([round(sum(date_counts) / len(date_counts)) for date_counts in counts_by_date.values()])
+
+        plt.plot(times, counts, linestyle='-', marker='.', alpha=0.75)
+
+        self.configure_plot(days_number, time_limit, today, min(counts), max(counts), "Nombre de membres", granularity)
+        await context.send(file=self.render_graph())
+
+    @graph.command(
+        name='messages',
+        aliases=['message'],
+        usage="[--time=days] [--hour|--day|--month|--year] [--split]",
+        brief="Affiche le nombre de messages postés lors de la dernière heure au cours du temps",
+        help="Par défaut, une période de 3 jours est utilisée. Pour changer cela il faut fournir l'argument "
+             "`--time=days` où `days` est le nombre de jours à considérer. L'axe du temps est automatiquement ajusté "
+             "au nombre de jours : Jusqu'à une période de 3 jours, 12 mois et 2 ans (exclus), l'axe affiche "
+             "respectivement des heures, des jours et des mois. Pour forcer un type d'affichage, il faut fournir l'un "
+             "des arguments suivants : `--hour`, `--day`, `--month`, `--year`. Il est également possible de scinder "
+             "l'affichage par canal en fournissant l'argument `--split`.",
+        ignore_extra=True,
+    )
+    @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
+    async def graph_messages(self, context, *, options=""):
+        days_number, granularity = await self.parse_time_arguments(options, default_days_number=2)
+        do_split = utils.is_option_enabled(options, 'split')
+
+        # Load, compute and reshape data
+        today = utils.com_tz_now()
+        time_limit = today - datetime.timedelta(days=days_number)
+        message_counts_data = zbot.db.load_message_counts(
+            {'time': {'$gt': time_limit}}, ['time', 'count', 'channel_id']
+        )
+        times_by_channel, counts_by_channel = {}, {}
+        if granularity == 'hour':  # Plot the time and exact value to place the dot accurately
+            for data in message_counts_data:
+                localized_time = converter.to_community_tz(converter.to_utc(data['time']))
+                times_by_channel.setdefault(data['channel_id'], []).append(localized_time)
+                counts_by_channel.setdefault(data['channel_id'], []).append(data['count'])
+        elif granularity in ('day', 'month', 'year'):  # Only plot the date and the average value to align with the tick
+            counts_by_channel_and_time = {}
+            for data in message_counts_data:
+                localized_time = converter.to_community_tz(converter.to_utc(data['time']))
+                counts_by_channel_and_time.setdefault(data['channel_id'], {}) \
+                    .setdefault(localized_time.date(), []).append(data['count'])
+            for channel, counts_by_date in counts_by_channel_and_time.items():
+                times_by_channel[channel] = list(counts_by_date.keys())
+                counts_by_channel[channel] = [
+                    round(sum(date_counts) / len(date_counts)) for date_counts in counts_by_date.values()
+                ]
+
+        min_count, max_count = float('inf'), -float('inf')
+        if do_split:
+            for channel_id, times, channel_counts in zip(
+                    times_by_channel.keys(), times_by_channel.values(), counts_by_channel.values()
+            ):
+                channel_name = self.guild.get_channel(channel_id).name
+                plt.plot(times, channel_counts, label=f"#{channel_name}", linestyle='-', marker='.', alpha=0.75)
+                plt.legend()
+                if min(channel_counts) < min_count:
+                    min_count = min(channel_counts)
+                if max(channel_counts) > max_count:
+                    max_count = max(channel_counts)
+        else:
+            times = list(times_by_channel.values())[0]
+            counts = [0] * len(times)
+            for channel_counts in counts_by_channel.values():
+                for time_index, channel_count in enumerate(channel_counts):
+                    counts[time_index] += channel_count
+            plt.plot(times, counts, linestyle='-', marker='.', alpha=0.75)
+            min_count, max_count = min(counts), max(counts)
+
+        self.configure_plot(
+            days_number, time_limit, today, min_count, max_count, "Nombre de messages horaires", granularity
+        )
+        await context.send(file=self.render_graph())
+
+    @staticmethod
+    async def parse_time_arguments(options, default_days_number=30):
         # Check arguments
         time_option = utils.get_option_value(options, 'time')
         if time_option is not None:  # Value assigned
@@ -135,32 +248,28 @@ class Server(_command.Command):
         elif utils.is_option_enabled(options, 'time', has_value=True):  # No value assigned
             raise exceptions.MisformattedArgument(time_option, "valeur entière")
         else:  # Option not used
-            days_number = 30
+            days_number = default_days_number
 
-        # Load, compute and reshape data
-        today = converter.get_tz_aware_datetime_now()
-        time_limit = today - datetime.timedelta(days=days_number)
+        # Determine granularity
+        granularity = None
+        for granularity_option in ('hour', 'day', 'month', 'year'):
+            if utils.is_option_enabled(options, granularity_option):
+                granularity = granularity_option
+                break
+        if not granularity:
+            granularity = 'hour' if days_number < Server.HOURS_GRANULARITY_LIMIT \
+                else 'day' if days_number < Server.DAYS_GRANULARITY_LIMIT \
+                else 'month' if days_number < Server.MONTHS_GRANULARITY_LIMIT \
+                else 'year'
+        return days_number, granularity
+
+    @staticmethod
+    def configure_plot(days_number, time_limit, today, min_count, max_count, count_name, granularity):
+        # Set labels
+        plt.xlabel("Temps")
+        plt.ylabel(count_name)
         years_number = today.year - time_limit.year
         months_number = years_number * 12 + (today.month - time_limit.month)
-        granularity = 'hour' if days_number < self.HOURS_GRANULARITY_LIMIT \
-            else 'day' if days_number < self.DAYS_GRANULARITY_LIMIT \
-            else 'month' if days_number < self.MONTHS_GRANULARITY_LIMIT \
-            else 'year'
-        member_counts_data = zbot.db.load_member_counts({'time': {'$gt': time_limit}}, ['count', 'time'])
-        times, counts = [], []
-        if granularity == 'hour':
-            times = [data['time'] for data in member_counts_data]
-            counts = [data['count'] for data in member_counts_data]
-        elif granularity in ('day', 'month', 'year'):  # Only plot the date and the average value to align with the tick
-            counts_by_time = {}
-            for data in member_counts_data:
-                counts_by_time.setdefault(data['time'].date(), []).append(data['count'])
-            times = list(counts_by_time.keys())
-            counts = [round(sum(time_counts) / len(time_counts)) for time_counts in counts_by_time.values()]
-
-        # Plot the graph
-        plt.clf()  # Clear the figure to remove any previous graph
-        count_name = "Nombre de membres"
         if granularity == 'hour':
             plt.title(f"{count_name} sur les {days_number * 24} dernières heures")
         elif granularity == 'day':
@@ -169,11 +278,9 @@ class Server(_command.Command):
             plt.title(f"{count_name} sur les {months_number} derniers mois")
         elif granularity == 'year':
             plt.title(f"{count_name} sur les {years_number} dernières années")
-        plt.xlabel("Temps")
-        plt.ylabel(count_name)
-        plt.plot(times, counts, linestyle='-', marker='.', alpha=0.75)
+
         # Format time axis to comply with granularity
-        plt.xlim(left=time_limit, right=today)
+        plt.xlim(left=converter.to_community_tz(time_limit), right=converter.to_community_tz(today))
         if granularity == 'hour':
             plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%d/%m %H:%M'))
             plt.gca().xaxis.set_major_locator(ticker.MaxNLocator(nbins=5))
@@ -186,19 +293,22 @@ class Server(_command.Command):
         elif granularity == 'year':
             plt.gca().xaxis.set_major_formatter(mdates.DateFormatter('%m/%y'))
             plt.gca().xaxis.set_major_locator(ticker.MaxNLocator(nbins=min(10, days_number)))
+
         # Format count axis to show integers only, on 5 to 10 ticks
-        counts_range = max(counts) - min(counts) + 1
+        counts_range = max_count - min_count + 1
         if counts_range < 10:  # Force the positioning of counts in the middle of the range
             half_gap = (10 - counts_range) / 2
-            plt.ylim(bottom=min(counts)-math.floor(half_gap), top=max(counts) + math.ceil(half_gap))
+            plt.ylim(bottom=min_count - math.floor(half_gap), top=max_count + math.ceil(half_gap))
         plt.gca().yaxis.set_major_formatter(ticker.FuncFormatter(lambda y, _pos: str(int(y))))
         plt.gca().yaxis.set_major_locator(ticker.MaxNLocator(nbins=10))
 
-        # Upload on Discord
+    @staticmethod
+    def render_graph():
         buffer = io.BytesIO()  # Instantiate I/O buffer
         plt.gcf().savefig(buffer, format='png')  # Plot the graph and save it in the buffer
+        plt.clf()  # Clear the figure to avoid it being drawn over by following graphes
         buffer.seek(0)  # Rewind the buffer to 0th byte
-        await context.send(file=discord.File(buffer, 'graph.png'))
+        return discord.File(buffer, 'graph.png')
 
 
 def setup(bot):

--- a/zbot/cogs/stats.py
+++ b/zbot/cogs/stats.py
@@ -24,7 +24,7 @@ class Stats(_command.Command):
     DISPLAY_SEQUENCE = 3
     MOD_ROLE_NAMES = ['Administrateur']
     USER_ROLE_NAMES = ['Joueur']
-    ALLOWED_CHANNELS = ['général', 'gameplay', 'mentorat', 'spam', 'zbot', 'modération', 'logs']
+    COMMAND_CHANNELS = ['général', 'gameplay', 'mentorat', 'spam', 'zbot', 'modération', 'logs']
 
     CLAN_CONTACT_ROLE_NAME = 'Contact de clan'
     EXP_VALUES_FILE_PATH = pathlib.Path('./res/wn8_exp_values.json')
@@ -175,15 +175,15 @@ class Stats(_command.Command):
         embed.add_field(name="Identifiant", value=player_details['id'])
         embed.add_field(
             name="Création du compte",
-            value=converter.humanize_datetime(datetime.datetime.fromtimestamp(player_details['creation_timestamp']))
+            value=converter.humanize_datetime(converter.from_timestamp(player_details['creation_timestamp']))
         )
         embed.add_field(
             name="Dernière bataille",
-            value=converter.humanize_datetime(datetime.datetime.fromtimestamp(player_details['last_battle_timestamp']))
+            value=converter.humanize_datetime(converter.from_timestamp(player_details['last_battle_timestamp']))
         )
         embed.add_field(
             name="Dernière connexion",
-            value=converter.humanize_datetime(datetime.datetime.fromtimestamp(player_details['logout_timestamp']))
+            value=converter.humanize_datetime(converter.from_timestamp(player_details['logout_timestamp']))
         )
         if player_details['clan']:
             embed.add_field(
@@ -257,7 +257,7 @@ class Stats(_command.Command):
         )
         embed.add_field(
             name="Création du clan",
-            value=converter.humanize_datetime(datetime.datetime.fromtimestamp(clan_details['creation_timestamp']))
+            value=converter.humanize_datetime(converter.from_timestamp(clan_details['creation_timestamp']))
         )
         embed.add_field(name="Personnel", value=f"{clan_details['members_count']} membres")
         embed.add_field(name="Postulations", value="Autorisées" if clan_details['recruiting'] else "Refusées")

--- a/zbot/converter.py
+++ b/zbot/converter.py
@@ -6,36 +6,35 @@ import dateutil.parser
 import discord
 import emojis as emoji_lib
 import pytz
-from dateutil.tz import tzlocal
+import tzlocal
+from discord.ext import commands
 
 from zbot import zbot
-from discord.ext import commands
 from . import exceptions
 from . import utils
 
 COMMUNITY_TIMEZONE = pytz.timezone('Europe/Brussels')
-GUILD_TIMEZONE = pytz.timezone('UTC')
+DATABASE_TIMEZONE = pytz.timezone('UTC')
 
 
 # Time and timezone
 
 def to_datetime(instant: str, print_error=True) -> datetime.datetime:
-    local_time = None
+    time = None
     try:
         time = dateutil.parser.parse(instant)
-        local_time = COMMUNITY_TIMEZONE.localize(time)
     except (ValueError, OverflowError):
         if print_error:
             raise exceptions.MisformattedArgument(instant, "YYYY-MM-MM HH:MM:SS")
-    return local_time
+    return to_community_tz(time)
 
 
 def to_past_datetime(arg: str):
     """Convert to datetime and check if it is in the past."""
     time = to_datetime(arg)
-    if (utils.get_current_time() - time).total_seconds() <= 0:
+    if (utils.com_tz_now() - time).total_seconds() <= 0:
         argument_size = humanize_datetime(time)
-        max_argument_size = humanize_datetime(utils.get_current_time())
+        max_argument_size = humanize_datetime(utils.com_tz_now())
         raise exceptions.OversizedArgument(argument_size, max_argument_size)
     return time
 
@@ -43,35 +42,44 @@ def to_past_datetime(arg: str):
 def to_future_datetime(arg: str):
     """Convert to datetime and check if it is in the future."""
     time = to_datetime(arg)
-    if (utils.get_current_time() - time).total_seconds() > 0:
+    if (utils.com_tz_now() - time).total_seconds() > 0:
         argument_size = humanize_datetime(time)
-        min_argument_size = humanize_datetime(utils.get_current_time())
+        min_argument_size = humanize_datetime(utils.com_tz_now())
         raise exceptions.UndersizedArgument(argument_size, min_argument_size)
     return time
 
 
 def to_timestamp(time: datetime.datetime) -> int:
-    return int(time.timestamp())
+    return int(to_utc(time).timestamp())
 
 
 def from_timestamp(timestamp: int) -> datetime.datetime:
-    return datetime.datetime.fromtimestamp(timestamp)
+    return to_bot_tz(datetime.datetime.fromtimestamp(timestamp))
 
 
 def humanize_datetime(time: datetime.datetime) -> str:
-    return time.strftime('%d/%m/%Y à %Hh%M')
+    return to_community_tz(time).strftime('%d/%m/%Y à %Hh%M')
 
 
-def get_tz_aware_datetime_now() -> datetime.datetime:
-    return datetime.datetime.now(tzlocal())
+def to_bot_tz(time: datetime.datetime) -> datetime.datetime:
+    if not time.tzinfo:
+        return tzlocal.get_localzone().localize(time)
+    else:
+        return time.astimezone(tzlocal.get_localzone())
 
 
 def to_community_tz(time: datetime.datetime) -> datetime.datetime:
-    return COMMUNITY_TIMEZONE.localize(time)
+    if not time.tzinfo:
+        return COMMUNITY_TIMEZONE.localize(time)
+    else:
+        return time.astimezone(COMMUNITY_TIMEZONE)
 
 
-def to_guild_tz(time: datetime.datetime) -> datetime.datetime:
-    return GUILD_TIMEZONE.localize(time)
+def to_utc(time: datetime.datetime) -> datetime.datetime:
+    if not time.tzinfo:
+        return DATABASE_TIMEZONE.localize(time)
+    else:
+        return time.astimezone(DATABASE_TIMEZONE)
 
 
 # Emojis

--- a/zbot/scheduler.py
+++ b/zbot/scheduler.py
@@ -6,14 +6,14 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.interval import IntervalTrigger
 
+from . import converter
 from . import database
 from . import logger
-from . import utils
 
 STORED_JOB_MISFIRE_GRACE_TIME = int(timedelta(days=2).total_seconds())
 VOLATILE_JOB_MISFIRE_GRACE_TIME = int(timedelta(days=1).total_seconds())
 
-scheduler = AsyncIOScheduler(timezone=utils.TIMEZONE)
+scheduler = AsyncIOScheduler(timezone=converter.COMMUNITY_TIMEZONE)
 
 
 def setup(db: database.MongoDBConnector):

--- a/zbot/utils.py
+++ b/zbot/utils.py
@@ -5,13 +5,12 @@ import shlex
 import typing
 
 import discord
-import pytz
 from discord.ext import commands
 
+from . import converter
 from . import exceptions
 from . import logger
 
-TIMEZONE = pytz.timezone('Europe/Brussels')
 MAX_MESSAGE_LENGTH = 2000
 PLAYER_NAME_PATTERN = re.compile(
     r'^(\w+)'  # One-word player name
@@ -212,8 +211,27 @@ def parse_player(guild, player: typing.Union[discord.Member, str], fallback: dis
 
 # Miscellaneous
 
-def get_current_time():
-    return datetime.datetime.now(TIMEZONE)
+def com_tz_now():
+    """Return the current datetime for the community timezone."""
+    return converter.to_community_tz(datetime.datetime.now())
+
+
+def bot_tz_now():
+    """Return the current datetime for the bot timezone."""
+    return converter.to_bot_tz(datetime.datetime.now())
+
+
+def utc_now():
+    """Return the current datetime for the UTC timezone."""
+    return converter.to_utc(datetime.datetime.now())
+
+
+def is_time_elapsed(past_time, now, delay):
+    return past_time < now - delay
+
+
+def is_time_almost_elapsed(past_time, now, delay, tolerance: datetime.timedelta = datetime.timedelta(minutes=1)):
+    return is_time_elapsed(past_time, now, delay - tolerance)
 
 
 def is_option_enabled(options: str, option_name: str, has_value=False) -> bool:

--- a/zbot/zbot.py
+++ b/zbot/zbot.py
@@ -13,7 +13,7 @@ from . import error_handler
 from . import logger
 from . import scheduler
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 dotenv.load_dotenv()
 


### PR DESCRIPTION
- Added the subcommand 'graph messages' to plot the number of messages from the last hour over time. Closes #49
- Reworked the way timezones are handled to facilitate their manipulation.
- Allowed looping tasks to run if the cooldown is not exactly but almost elapsed to avoid triggering aborts for a matter of seconds.