### PR TITLE
Updated to version 1.6.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,12 @@ Each changelog must be formatted as follows in order to be correctly matched:
 ```
 where `a.b.c` is the version string.
 
+## 1.6.5 - 2020-10-31 - The "Police Inspector 101" best-seller has been given to moderators.
+- Added the command `inspect` and its subcommand `inspect recruitment` to provide the status of recruitment announces monitoring.
+- Made it possible to pass a member name as argument of the command `report recruitment`.
+- Added the option `--clear` to the command `report recruitment` to clear the author announce logs.
+- Added a check to the sub-commands of the command `poll` to remain below the limit of 20 reaction emojis.
+
 ## 1.6.4 - 2020-07-25 - Changelogs were thought to be mythical creatures before this version.
 - Added the command `changelog` to display the changes brought by a specific version.
 - Added the option `--all` to the command `version` to display all existing versions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 apscheduler
 asyncio
 dnspython
-discord.py>=1.3.4
+discord.py>=1.5.1
 emojis
 flask
 pymongo

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.3
+python-3.8.6

--- a/zbot/cogs/poll.py
+++ b/zbot/cogs/poll.py
@@ -87,6 +87,8 @@ class Poll(_command.Command):
             raise exceptions.ForbiddenChannel(dest_channel)
         if not emoji_list:
             raise commands.MissingRequiredArgument(context.command.params['emoji_list'])
+        if len(emoji_list) > 20:
+            raise exceptions.OversizedArgument(f"{len(emoji_list)} emojis", "20 emojis")
         do_announce = utils.is_option_enabled(options, 'do-announce')
         do_pin = utils.is_option_enabled(options, 'pin')
         if do_announce or do_pin:
@@ -437,6 +439,8 @@ class Poll(_command.Command):
             raise exceptions.ForbiddenChannel(channel)
         if not emoji_list:
             raise commands.MissingRequiredArgument(context.command.params['emoji_list'])
+        if len(emoji_list) > 20:
+            raise exceptions.OversizedArgument(f"{len(emoji_list)} emojis", "20 emojis")
         required_role_name = utils.get_option_value(options, 'role')
         if required_role_name:
             utils.try_get(  # Raise if role does not exist
@@ -635,6 +639,8 @@ class Poll(_command.Command):
                 )
             else:
                 emoji_list = [reaction.emoji for reaction in message.reactions]
+        elif len(emoji_list) > 20:
+            raise exceptions.OversizedArgument(f"{len(emoji_list)} emojis", "20 emojis")
 
         reactions, results = await Poll.count_votes(
             message, emoji_list, is_exclusive, required_role_name

--- a/zbot/utils.py
+++ b/zbot/utils.py
@@ -120,8 +120,9 @@ def try_get(iterable, error: commands.CommandError = None, **filters):
             raise error
 
 
-def try_get_emoji(emojis, emoji_code: typing.Union[str, int], error: commands.CommandError = None) \
-        -> typing.Union[str, discord.Emoji] or None:
+def try_get_emoji(
+    emojis, emoji_code: typing.Union[str, int], error: commands.CommandError = None
+) -> typing.Union[str, discord.Emoji] or None:
     """
     Attempt to retrieve an emoji by code (unicode string or integer ID) and raises if not found and
     if an error is provided.
@@ -140,8 +141,8 @@ def try_get_emoji(emojis, emoji_code: typing.Union[str, int], error: commands.Co
 
 
 async def try_get_message(
-        channel: discord.TextChannel, message_id: int, error: commands.CommandError = None) \
-        -> discord.Message:
+    channel: discord.TextChannel, message_id: int, error: commands.CommandError = None
+) -> discord.Message:
     """Attempt to retrieve a message by id and raises if not found and if an error is provided."""
     try:
         message = await channel.fetch_message(message_id)

--- a/zbot/zbot.py
+++ b/zbot/zbot.py
@@ -13,7 +13,7 @@ from . import error_handler
 from . import logger
 from . import scheduler
 
-__version__ = '1.6.4'
+__version__ = '1.6.5'
 
 dotenv.load_dotenv()
 
@@ -39,6 +39,7 @@ bot = commands.Bot(
     case_insensitive=True,
     help_command=None,
     owner_id=OWNER_ID,
+    intents=discord.Intents.all(),
 )
 
 db = database.MongoDBConnector()


### PR DESCRIPTION
- Updated to Python 3.8.6.
- Updated to discord.py 1.5.1.
- Update to Gateway Intents API.
- Added the command `inspect` and its subcommand `inspect recruitment` to provide the status of recruitment announces monitoring. Closes #59
- Made it possible to pass a member name as argument of the command `report recruitment`. Closes #60
- Added the option `--clear` to the command `report recruitment` to clear the author announce logs. Closes #58
- Added a check to the sub-commands of the command `poll` to remain below the limit of 20 reaction emojis.