### PR TITLE
Updated to version 1.6.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,15 @@ Each changelog must be formatted as follows in order to be correctly matched:
 ```
 where `a.b.c` is the version string.
 
+## 1.6.6 - 2021-07-04 - Help to prevent depression among our moderators by following the server rules.
+- Added the command `validate` and its subcommand `validate announce` to help clan contacts check that their announce follows the server rules.
+- Made the command `inspect recruitment` exclude members that are no longer clan contacts.
+- Added the option `--all` to the command `inspect recruitment` to include all members no matter the role.
+- Added the aliases 'announce' and 'annonce' to all commands named 'recruitment'.
+- Added a mention of the command 'validate announce' to the analysis report sent to the clan contact by the command `report recruitment`.
+- Fixed the command `report recruitment` not mentioning duplicate announces.
+- Fixed the command `report recruitment` crashing if the clan contact had deleted all their announce before running the command.
+
 ## 1.6.5 - 2020-10-31 - The "Police Inspector 101" best-seller has been given to moderators.
 - Added the command `inspect` and its subcommand `inspect recruitment` to provide the status of recruitment announces monitoring.
 - Made it possible to pass a member name as argument of the command `report recruitment`.
@@ -42,7 +51,7 @@ where `a.b.c` is the version string.
 - Fixed commands `check recruitment` and `report recruitment` treating announces posted before the last registration date of a deleted announce as illegal.
 - Fixed command `lottery cancel` crash.
 
-## 1.6.0 - 2020-06-27 - How many members per role ?
+## 1.6.0 - 2020-06-27 - How many members per role?
 - Added the command `members` to display the number of members per role.
 
 ## 1.5.5 - 2020-06-21 - Edit existing automessages.

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import sys
 import keep_alive
 import zbot.zbot as bot
 
-MIN_PYTHON = (3, 8)
+MIN_PYTHON = (3, 9)
 if sys.version_info < MIN_PYTHON:
     sys.exit("Python %s.%s or later is required." % MIN_PYTHON)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 apscheduler
 asyncio
 dnspython
-discord.py>=1.5.1
+discord.py>=1.7.3
 emojis
 flask
 pymongo

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.6
+python-3.9.0

--- a/zbot/cogs/_command.py
+++ b/zbot/cogs/_command.py
@@ -16,8 +16,15 @@ class Command(commands.Cog):
     COMMAND_CHANNELS = ['spam', 'zbot', 'modération', 'logs']
     EMBED_COLOR = 0xFAA61A  # Mention message color (gold)
 
+    send_buffer = []  # Serves as a buffer for the message sent to the context
+
     def __init__(self, bot):
         self.bot = bot
         self.user = self.bot.user
         self.guild = self.bot.get_guild(GUILD_ID)
         self.app_id = os.getenv('WG_API_APPLICATION_ID') or 'demo'
+
+    @staticmethod
+    async def mock_send(content=None, *_args, **_kwargs):
+        """Catch all messages sent to the context whose `send` method has been matched with this."""
+        Command.send_buffer.append(content)

--- a/zbot/cogs/bot.py
+++ b/zbot/cogs/bot.py
@@ -69,7 +69,7 @@ class Bot(_command.Command):
             else:
                 # Don't show the helper of all matching commands if one matches exactly
                 if exactly_matching_commands := set(filter(
-                        lambda c: c.qualified_name == full_command_name, matching_commands
+                    lambda c: c.qualified_name == full_command_name, matching_commands
                 )):
                     matching_commands = exactly_matching_commands
 
@@ -84,6 +84,7 @@ class Bot(_command.Command):
                         else:  # At least one command is public
                             matching_commands = public_commands  # Filter out hidden commands
 
+                # Show the helper of matching commands
                 sorted_matching_commands = sorted(matching_commands, key=lambda c: c.qualified_name)
                 for command in sorted_matching_commands:
                     if isinstance(command, commands.Group):
@@ -253,7 +254,7 @@ class Bot(_command.Command):
             await context.send(f"Aucune note de version trouvée pour @{bot_display_name} v{version}")
         else:  # This is only executed if there is a match and if both the date and changes are present
             date_iso, description, raw_changes = changelog
-            changes = [raw_change.lstrip('-').strip() for raw_change in raw_changes.split('\n') if raw_change]
+            changes = [raw_change.removeprefix('- ') for raw_change in raw_changes.split('\n') if raw_change]
             embed = discord.Embed(
                 title=f"Notes de version de @{bot_display_name} v{version}",
                 description="",

--- a/zbot/cogs/lottery.py
+++ b/zbot/cogs/lottery.py
@@ -21,7 +21,7 @@ class Lottery(_command.Command):
 
     """Commands for management of lotteries."""
 
-    DISPLAY_NAME = "Loteries & Tirages au sort"
+    DISPLAY_NAME = "Loteries et tirages au sort"
     DISPLAY_SEQUENCE = 5
     MOD_ROLE_NAMES = ['Administrateur', 'Modérateur', 'Annonceur']
     USER_ROLE_NAMES = ['Joueur']
@@ -70,13 +70,13 @@ class Lottery(_command.Command):
     @commands.check(checker.has_any_mod_role)
     @commands.check(checker.is_allowed_in_current_guild_channel)
     async def setup(
-            self, context: commands.Context,
-            announce: str,
-            dest_channel: discord.TextChannel,
-            emoji: converter.to_emoji,
-            nb_winners: converter.to_positive_int,
-            time: converter.to_future_datetime,
-            *, options=""
+        self, context: commands.Context,
+        announce: str,
+        dest_channel: discord.TextChannel,
+        emoji: converter.to_emoji,
+        nb_winners: converter.to_positive_int,
+        time: converter.to_future_datetime,
+        *, options=""
     ):
         # Check arguments
         if not context.author.permissions_in(dest_channel).send_messages:
@@ -298,10 +298,10 @@ class Lottery(_command.Command):
     @commands.check(checker.has_any_user_role)
     @commands.check(checker.is_allowed_in_current_guild_channel)
     async def announce(
-            self, context: commands.Context,
-            lottery_id: int,
-            announce: str,
-            *, options=""
+        self, context: commands.Context,
+        lottery_id: int,
+        announce: str,
+        *, options=""
     ):
         message, channel, _, _, _, organizer = await self.get_message_env(
             lottery_id, raise_if_not_found=True
@@ -368,9 +368,9 @@ class Lottery(_command.Command):
     @commands.check(checker.has_any_user_role)
     @commands.check(checker.is_allowed_in_current_guild_channel)
     async def organizer(
-            self, context: commands.Context,
-            lottery_id: int,
-            organizer: discord.User
+        self, context: commands.Context,
+        lottery_id: int,
+        organizer: discord.User
     ):
         message, channel, emoji, nb_winners, time, previous_organizer = \
             await self.get_message_env(lottery_id, raise_if_not_found=True)
@@ -402,9 +402,9 @@ class Lottery(_command.Command):
     @commands.check(checker.has_any_user_role)
     @commands.check(checker.is_allowed_in_current_guild_channel)
     async def time(
-            self, context: commands.Context,
-            lottery_id: int,
-            time: converter.to_future_datetime
+        self, context: commands.Context,
+        lottery_id: int,
+        time: converter.to_future_datetime
     ):
         message, channel, emoji, nb_winners, _, organizer = \
             await self.get_message_env(lottery_id, raise_if_not_found=True)
@@ -436,9 +436,9 @@ class Lottery(_command.Command):
     @commands.check(checker.has_any_user_role)
     @commands.check(checker.is_allowed_in_current_guild_channel)
     async def winners(
-            self, context: commands.Context,
-            lottery_id: int,
-            nb_winners: converter.to_positive_int
+        self, context: commands.Context,
+        lottery_id: int,
+        nb_winners: converter.to_positive_int
     ):
         message, channel, emoji, _, time, organizer = \
             await self.get_message_env(lottery_id, raise_if_not_found=True)
@@ -459,9 +459,9 @@ class Lottery(_command.Command):
         )
 
     @staticmethod
-    async def get_message_env(lottery_id: int, raise_if_not_found=True) -> \
-            (discord.Message, discord.TextChannel, typing.Union[str, discord.Emoji],
-             datetime.datetime, str, discord.Member):
+    async def get_message_env(lottery_id: int, raise_if_not_found=True) -> (
+        discord.Message, discord.TextChannel, typing.Union[str, discord.Emoji], datetime.datetime, str, discord.Member
+    ):
         if not (lottery_data := discord.utils.find(
                 lambda data: data['lottery_id'] == lottery_id,
                 Lottery.pending_lotteries.values()
@@ -512,14 +512,14 @@ class Lottery(_command.Command):
     @commands.check(checker.has_any_user_role)
     @commands.check(checker.is_allowed_in_current_guild_channel)
     async def simulate(
-            self, context: commands.Context,
-            src_channel: discord.TextChannel,
-            message_id: int,
-            emoji: converter.to_emoji = None,
-            nb_winners: converter.to_positive_int = 1,
-            dest_channel: discord.TextChannel = None,
-            organizer: discord.User = None,
-            seed: int = None
+        self, context: commands.Context,
+        src_channel: discord.TextChannel,
+        message_id: int,
+        emoji: converter.to_emoji = None,
+        nb_winners: converter.to_positive_int = 1,
+        dest_channel: discord.TextChannel = None,
+        organizer: discord.User = None,
+        seed: int = None
     ):
         if dest_channel and not context.author.permissions_in(dest_channel).send_messages:
             raise exceptions.ForbiddenChannel(dest_channel)
@@ -570,8 +570,7 @@ class Lottery(_command.Command):
 
     @staticmethod
     async def announce_winners(
-            winners: [discord.User], players: [discord.User], message,
-            organizer: discord.User = None
+        winners: [discord.User], players: [discord.User], message, organizer: discord.User = None
     ):
         embed = discord.Embed(
             title="Résultats du tirage au sort 🎉",

--- a/zbot/cogs/server.py
+++ b/zbot/cogs/server.py
@@ -21,7 +21,7 @@ from .bot import Bot
 
 class Server(_command.Command):
 
-    """Commands for information about the bot."""
+    """Commands for information about the server."""
 
     DISPLAY_NAME = "Informations sur le serveur"
     DISPLAY_SEQUENCE = 2
@@ -33,7 +33,7 @@ class Server(_command.Command):
     SERVER_STATS_RECORD_FREQUENCY = datetime.timedelta(hours=1)  # How often server stats are recorded
     HOURS_GRANULARITY_LIMIT = 3  # In days, the maximum time-frame (excl.) to display records on a datetime axis
     DAYS_GRANULARITY_LIMIT = 365  # In days, the maximum time-frame (excl.) to display records on a day-to-day date axis
-    MONTHS_GRANULARITY_LIMIT = 365*2  # In days, the maximum time-frame (excl.) to display records on a month axis
+    MONTHS_GRANULARITY_LIMIT = 365 * 2  # In days, the maximum time-frame (excl.) to display records on a month axis
     DISCUSSION_CHANNELS = [
         'général', 'gameplay', 'mentorat', 'actualités', 'promotion', 'recrutement', 'suggestions', 'memes']
     PRIMARY_ROLES = [
@@ -156,7 +156,7 @@ class Server(_command.Command):
                 localized_time = converter.to_community_tz(converter.to_utc(data['time'])).replace(tzinfo=None)
                 times.append(localized_time)
                 counts.append(data['count'])
-        elif granularity in ('day', 'month', 'year'):  # Only plot the date and the average value to align with the tick
+        elif granularity in ('day', 'month', 'year'):  # Only plot the date, and average value to align with the tick
             counts_by_date = {}
             for data in member_counts_data:
                 localized_time = converter.to_community_tz(converter.to_utc(data['time']))
@@ -200,7 +200,7 @@ class Server(_command.Command):
                 localized_time = converter.to_community_tz(converter.to_utc(data['time'])).replace(tzinfo=None)
                 times_by_channel.setdefault(data['channel_id'], []).append(localized_time)
                 counts_by_channel.setdefault(data['channel_id'], []).append(data['count'])
-        elif granularity in ('day', 'month', 'year'):  # Only plot the date and the average value to align with the tick
+        elif granularity in ('day', 'month', 'year'):  # Only plot the date, and average value to align with the tick
             counts_by_channel_and_time = {}
             for data in message_counts_data:
                 localized_time = converter.to_community_tz(converter.to_utc(data['time']))

--- a/zbot/cogs/special.py
+++ b/zbot/cogs/special.py
@@ -1,0 +1,117 @@
+import datetime
+from copy import copy
+
+from discord.ext import commands
+
+from zbot import checker
+from zbot import converter
+from zbot import exceptions
+from zbot import zbot
+from . import _command
+from .admin import Admin
+from .bot import Bot
+from .stats import Stats
+
+
+class Special(_command.Command):
+    """Special commands tailored for specific roles"""
+
+    DISPLAY_NAME = "Commandes spéciales"
+    DISPLAY_SEQUENCE = 7
+    USER_ROLE_NAMES = ['Joueur']
+
+    def __init__(self, bot):
+        super().__init__(bot)
+
+    @commands.group(
+        name='validate',
+        aliases=['valider'],
+        brief="Valide le suivi du règlement",
+        invoke_without_command=True
+    )
+    @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
+    async def validate(self, context):
+        if not context.subcommand_passed:
+            await Bot.display_group_help(context, context.command)
+        else:
+            raise exceptions.MissingSubCommand(context.command.name)
+
+    @validate.command(
+        name='announce',
+        aliases=['annonce', 'recruitment', 'recrutement', 'recrut'],
+        usage="",
+        brief="Valide le suivi du règlement d'une annonce de recrutement",
+        help="La validation consiste à vérifier que :\n"
+             "• Le membre possède le rôle \"Contact de clan\"\n"
+             "• Le contact de clan n'a posté au maximum qu'une seule annonce à la fois\n"
+             "• La longueur de l'annonce est inférieure à 1200 caractères (min 100/ligne)\n"
+             "• L'annonce ne contient aucun embed\n"
+             "• L'annonce précédente est antérieure à 30 jours",
+        ignore_extra=False
+    )
+    @commands.check(checker.has_any_user_role)
+    @commands.check(checker.is_allowed_in_current_guild_channel)
+    async def validate_recruitments(self, context):
+        if not checker.has_guild_role(context.guild, context.author, Stats.CLAN_CONTACT_ROLE_NAME):
+            raise exceptions.MissingRoles([Stats.CLAN_CONTACT_ROLE_NAME])
+
+        recruitment_channel = self.guild.get_channel(Admin.RECRUITMENT_CHANNEL_ID)
+        all_recruitment_announces = await recruitment_channel.history().flatten()
+        recruitment_announces = list(filter(lambda a: a.author == context.author, all_recruitment_announces))
+        last_recruitment_announce = recruitment_announces and recruitment_announces[0]
+
+        if not last_recruitment_announce:
+            await context.send("Aucune annonce de recrutement n'a été trouvée.")
+        else:
+            patched_context = copy(context)
+            patched_context.send = self.mock_send
+            validation_succeeded = True
+            if await Admin.check_recruitment_announces_uniqueness(patched_context, recruitment_announces):
+                validation_succeeded = False
+                await context.send(
+                    f"Tu as publié {len(recruitment_announces)} annonces. Une seule est autorisée à la fois."
+                )
+            if await Admin.check_recruitment_announces_length(patched_context, [last_recruitment_announce]):
+                validation_succeeded = False
+                apparent_length = Admin.compute_apparent_length(last_recruitment_announce)
+                await context.send(
+                    f"L'annonce est d'une longueur apparente de **{apparent_length}** caractères (max "
+                    f"{Admin.MAX_RECRUITMENT_ANNOUNCE_LENGTH}). Réduit sa longueur en retirant du contenu ou en "
+                    f"réduisant le nombre de sauts de lignes."
+                )
+            if await Admin.check_recruitment_announces_embeds(patched_context, [last_recruitment_announce]):
+                validation_succeeded = False
+                await context.send(
+                    f"Ton annonce contient un embed, ce qui n'est pas autorisé. Utilise un raccourcisseur d'URLs comme "
+                    f"<https://tinyurl.com> pour héberger tes liens."
+                )
+            if await Admin.check_recruitment_announces_timespan(
+                patched_context, recruitment_channel, [last_recruitment_announce]
+            ):
+                validation_succeeded = False
+                await context.send(
+                    f"Ton annonce a été postée avant le délai minimum de {Admin.MIN_RECRUITMENT_ANNOUNCE_TIMESPAN} "
+                    f"jours entre deux annonces."
+                )
+
+            if validation_succeeded:
+                await context.send(f"L'annonce ne présente aucun problème. :ok_hand: ")
+
+            last_announce_time_localized = converter.to_utc(zbot.db.load_recruitment_announces_data(
+                query={'author': context.author.id}, order=[('time', -1)]
+            )[0]['time'])
+            min_timespan = datetime.timedelta(
+                # Apply a tolerance of 2 days for players interpreting the 30 days range as "one month".
+                # This is a subtraction because the resulting value is the number of days to wait before posting again.
+                days=Admin.MIN_RECRUITMENT_ANNOUNCE_TIMESPAN - Admin.RECRUITMENT_ANNOUNCE_TIMESPAN_TOLERANCE
+            )
+            next_announce_time_localized = last_announce_time_localized + min_timespan
+            await context.send(
+                f"Tu pourras à nouveau poster une annonce à partir du "
+                f"{converter.to_human_format(next_announce_time_localized)}."
+            )
+
+
+def setup(bot):
+    bot.add_cog(Special(bot))

--- a/zbot/error_handler.py
+++ b/zbot/error_handler.py
@@ -55,7 +55,10 @@ async def handle(context, error):
     elif isinstance(error, exceptions.MissingEmoji):
         await context.send(f"Cet emoji n'a pas été trouvé : {error.missing_emoji}")
     elif isinstance(error, exceptions.MissingMessage):
-        await context.send(f"Aucun message trouvé pour l'id : `{error.missing_message_id}`")
+        if error.missing_message_id:
+            await context.send(f"Aucun message trouvé pour l'id : `{error.missing_message_id}`")
+        else:
+            await context.send("Aucun message trouvé.")
     elif isinstance(error, exceptions.MissingRoles):
         await context.send(f"Rôle(s) requis : {', '.join([f'@{r}' for r in error.missing_roles])}")
     elif isinstance(error, exceptions.MissingSubCommand):

--- a/zbot/utils.py
+++ b/zbot/utils.py
@@ -109,7 +109,7 @@ def make_announce(guild, announce: str, announce_role_name: str = None) -> str:
 # Safe utilities
 
 def try_get(iterable, error: commands.CommandError = None, **filters):
-    """Attempt to find a element and raises if not found and if an error is provided."""
+    """Attempt to find a first matching element and raises if not found and if an error is provided."""
     try:
         result = discord.utils.get(iterable, **filters)
         if not result and error:

--- a/zbot/zbot.py
+++ b/zbot/zbot.py
@@ -13,7 +13,7 @@ from . import error_handler
 from . import logger
 from . import scheduler
 
-__version__ = '1.6.5'
+__version__ = '1.6.6'
 
 dotenv.load_dotenv()
 
@@ -25,6 +25,7 @@ COGS = [
     'zbot.cogs.poll',
     'zbot.cogs.messaging',
     'zbot.cogs.server',
+    'zbot.cogs.special',
     'zbot.cogs.stats',
 ]
 


### PR DESCRIPTION
- Made the command `inspect recruitment` exclude members that are no longer clan contacts.
- Added the option `--all` to the command `inspect recruitment` to include all members no matter the role.