### PR TITLE
Updated to version 1.6.7

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,11 @@ Each changelog must be formatted as follows in order to be correctly matched:
 ```
 where `a.b.c` is the version string.
 
+## 1.6.7 - 2021-08-29 - Sky is the limit for the command `check players`.
+- Allowed the command `check players` to pinpoint invalid player names breaking the check instead of stating that no player of the whole batch has a matching WoT account.
+- Fixed the command `check players` crashing if too many long player names were checked at once.
+- Improved performances of the command `check players` (4 times faster).
+
 ## 1.6.6 - 2021-07-04 - Help to prevent depression among our moderators by following the server rules.
 - Added the command `validate` and its subcommand `validate announce` to help clan contacts check that their announce follows the server rules.
 - Made the command `inspect recruitment` exclude members that are no longer clan contacts.

--- a/zbot/utils.py
+++ b/zbot/utils.py
@@ -13,9 +13,9 @@ from . import logger
 
 MAX_MESSAGE_LENGTH = 2000
 PLAYER_NAME_PATTERN = re.compile(
-    r'^(\w+)'  # One-word player name
-    r'([ ]\[([\w-]{2,5})\])?'  # Space-separated clan tag between square brackets
-    r'([ ](🕯+))?$'  # Space-separated arbitrary repetition of an emoji
+    r'^(\w{3,24})'            # One-word player name
+    r'([ ]\[([\w-]{2,5})])?'  # Space-separated clan tag between square brackets
+    r'([ ](🕯+))?$'            # Space-separated arbitrary repetition of an emoji
 )
 
 
@@ -264,8 +264,8 @@ def remove_option(options: str, option_name: str) -> str:
     return re.sub(p, '', options).rstrip()
 
 
-def sanitize_player_names(member_names):
-    """Filter out member names that do not follow either the `player` or `player [CLAN]` pattern."""
+def sanitize_player_names(member_names) -> list:
+    """Filter out member names that do not match `PLAYER_NAME_PATTERN`."""
     sanitized_player_names = []
     for member_name in member_names:
         result = PLAYER_NAME_PATTERN.match(member_name)

--- a/zbot/zbot.py
+++ b/zbot/zbot.py
@@ -13,7 +13,7 @@ from . import error_handler
 from . import logger
 from . import scheduler
 
-__version__ = '1.6.6'
+__version__ = '1.6.7'
 
 dotenv.load_dotenv()
 


### PR DESCRIPTION
- Allowed the command `check players` to pinpoint invalid player names breaking the check instead of stating that no player of the whole batch has a matching WoT account.
- Fixed the command `check players` crashing if too many long player names were checked at once.
- Improved performances of the command `check players` (4 times faster).